### PR TITLE
change the base URL of Twemoji to accommodate the discontinuation of MaxCDN

### DIFF
--- a/src/components/EmojiInputArea.tsx
+++ b/src/components/EmojiInputArea.tsx
@@ -27,7 +27,7 @@ export const EmojiInputArea: FC = () => {
     // NOTE: **Contribute Chance**
     // The URLs are different fro png and svg, but the `parse` function does not support it.
     twemoji.parse(document.body, {
-      base: "https://twemoji.maxcdn.com/v/latest/svg/",
+      base: "https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/",
       ext: ".svg",
       className: "w-full h-full",
       size: "/",


### PR DESCRIPTION
## Motivation

To address the issue of https://github.com/twitter/twemoji/issues/556.

## Approach

Use jsDelivr CDN instead of MaxCDN.

## Acknowledgement

I learned about this issue by reading this [article](https://zenn.dev/yhatt/articles/60ce0c3ca79994). Thanks!!