### PR TITLE
Enhance testing and linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {"no-console": "error"}
 }

--- a/src/features/OgiriPicture/test/__snapshots__/index.test.tsx.snap
+++ b/src/features/OgiriPicture/test/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OgiriPicture renders the Ōgiri picture unchanged 1`] = `
+<div>
+  <div
+    tw="flex bg-white flex-col justify-center items-center"
+  >
+    <div
+      tw="w-60 h-60 mx-auto mt-12 flex justify-center items-center text-[15rem]"
+    >
+      🥳
+    </div>
+    <div
+      tw="flex max-w-full"
+    >
+      <div
+        tw="shrink px-4 py-2 min-h-[3rem] border-[#A6ADBA] rounded-lg flex flex-col mx-32 my-8 w-full"
+      >
+        <span
+          style="word-break: break-all;"
+          tw="w-full text-[#191D24] text-center justify-center bg-transparent text-5xl"
+        >
+          dummy text
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/features/OgiriPicture/test/index.test.tsx
+++ b/src/features/OgiriPicture/test/index.test.tsx
@@ -1,0 +1,9 @@
+import { render } from "@testing-library/react";
+import { OgiriPicture } from "..";
+
+describe("OgiriPicture", () => {
+  it("renders the Ōgiri picture unchanged", async () => {
+    const { container } = render(<OgiriPicture emoji="🥳" text="dummy text" />);
+    expect(container).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Motivation

1. Want to ensure that unintended changes to the OG image do not occur
2. Want to make sure that `console` doesn't get mixed up

## Approach

1. Add a snapshot test because it is sufficient to ensure that the appearance of the OG image does not change
2. Add an ESLint rule